### PR TITLE
Restore FastAPI service and uvicorn startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,59 +51,139 @@ pip install -r requirements.txt
 
 ## ▶️ Usage
 
+Start the FastAPI service with Uvicorn:
+
 ```bash
-python app.py
+uvicorn predict:app --app-dir /workspace --host 0.0.0.0 --port 8000 --workers 2
 ```
+
+The API will be available at `http://0.0.0.0:8000` (or `http://127.0.0.1:8000` locally). The two primary endpoints are `/train` and `/predict`.
 
 ---
 
-## 🧪 Example API Request (for Postman or cURL)
+## 🔌 REST API Endpoints
 
-### Endpoint
+### `POST /train`
 
-```
-POST http://localhost:8080/run
-Content-Type: application/json
-```
+Trains (or retrains) the forecasting and state-of-charge models for a specific user.
 
-### Body (JSON)
+**Request body**
 
-```json
+```jsonc
 {
-  "uid": "user123",
-  "historical": [
+  "uid": "user123",            // Unique user identifier (required)
+  "historical": [               // Time-ordered hourly history (required)
     {
       "month": 10,
       "day": 6,
       "hour": 14,
       "clouds": 35,
-      "power": 10,
+      "power": 10.0,
       "generation": 7.5,
       "consumption": 4.2,
-      "purchase": 0.0,
-      "battery_capacity": 45,
-      "soc": 60,
-      "price": 4.32
+      "battery_capacity": 45.0,
+      "soc": 60.0,
+      "price": 4.32,
+      "temperature": 12.3,      // optional (default 0.0)
+      "irradiance": 320.0       // optional (default 0.0)
     }
-    // ...
+    // ... more records ...
   ],
-  "forecast": [
+  "train_window_days": 14       // optional: truncate history to the last N days
+}
+```
+
+> ℹ️ Provide at least 24 + 24 = 48 hourly records so the model can build one training sequence. More history improves training quality.
+
+**Successful response**
+
+```json
+{
+  "status": "trained",
+  "uid": "user123",
+  "last_trained": "2024-05-01 10:22:48",
+  "train_records": 336,
+  "train_window_days": 14,
+  "metrics": {
+    "forecaster_train_loss": 0.0021,
+    "forecaster_val_loss": 0.0024,
+    "soc_train_loss": 0.0018,
+    "soc_val_loss": 0.0020,
+    "avg_slot_costs": [1.82, 1.76, 1.71, ...]
+  }
+}
+```
+
+Errors are returned as `{ "error": "message" }` with HTTP status `400` for invalid payloads or `500` for unexpected failures.
+
+---
+
+### `POST /predict`
+
+Generates the next-day energy strategy for a previously trained user.
+
+**Request body**
+
+```jsonc
+{
+  "uid": "user123",               // required
+  "forecast_24h": [               // list of 24+ hourly forecast records (required)
     {
       "month": 10,
       "day": 7,
       "hour": 8,
       "clouds": 25,
-      "soc": 55,
-      "price": 4.32
+      "temperature": 9.4,
+      "irradiance": 240.0,
+      "generation": 6.1,         // optional (defaults to 0.0)
+      "consumption": 3.8,        // optional (defaults to 0.0)
+      "price": 4.32,             // optional (defaults to 0.0)
+      "power": 10.0              // optional (falls back to request-level power)
     }
-    // ...
-  ]
+    // ... 23 more entries ...
+  ],
+  "soc_current": 58.0,            // optional: current battery SOC (%). Defaults to 0 or current.soc
+  "power": 10.0,                  // optional: max charge/discharge power (kW)
+  "battery_capacity": 45.0,       // optional: battery capacity (kWh)
+  "current": {                    // optional: latest measured point, used as fallback for missing values
+    "month": 10,
+    "day": 6,
+    "hour": 23,
+    "clouds": 48,
+    "power": 10.0,
+    "generation": 8.0,
+    "consumption": 5.1,
+    "battery_capacity": 45.0,
+    "soc": 58.0,
+    "price": 4.18
+  }
 }
 ```
 
-💡 In a real use case:
-- `historical` should contain at least several days (e.g., 14 × 24 = 336 records)
-- `forecast` must include exactly 24 records (one per hour for the next day)
+**Successful response**
+
+```json
+{
+  "generation_pred": [6.0, 6.1, ...],
+  "consumption_pred": [3.5, 3.8, ...],
+  "slots": [
+    {
+      "start_hour": 0,
+      "end_hour": 4,
+      "soc_target_pct": 62.5,
+      "estimated_cost": 1.72
+    }
+    // ... aggregated 4-hour slots covering 24h ...
+  ],
+  "strategy_cost": {
+    "slot_costs": [1.72, 1.68, ...],
+    "total_cost": 10.21
+  },
+  "model_soc_targets": [61.8, 63.1, ...]
+}
+```
+
+If the payload is invalid or the user has not been trained yet, the endpoint responds with `{ "error": "message" }` and HTTP status `400` or `500` depending on the failure.
 
 ---
 
@@ -113,12 +193,13 @@ Content-Type: application/json
 - Pandas — data processing
 - Matplotlib — visualization
 - Requests — API integration
-- Flask — REST API
+- FastAPI — REST API
+- Uvicorn — ASGI server
 - Numpy, scikit-learn, joblib — ML logic
 
 ---
 
-**Skynix Team**  
+**Skynix Team**
 [https://skynix.co/about-skynix](https://skynix.co/about-skynix)
 
 A professional software development company specializing in advanced AI automation and energy efficiency systems.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-flask
+fastapi
+uvicorn
 numpy
 pandas
 scikit-learn


### PR DESCRIPTION
## Summary
- switch the API implementation back to FastAPI in `predict.py` and keep the existing JSON error contract
- update the README usage instructions to run the service with uvicorn and reflect the FastAPI/Uvicorn tech stack
- replace the Flask dependency with FastAPI/Uvicorn in the requirements list

## Testing
- python -m compileall predict.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69157ede15d0832091b9b7c5f464682e)